### PR TITLE
1.1-hotfix1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
-version = '1.1'
+version = '1.1-hotfix1'
 group = 'ca.zandercraft.doorknockerforge' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'doorknockerforge'
 

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -3,7 +3,7 @@
 # The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
 modLoader="javafml"
 # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
-loaderVersion="[36,)" # This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
+loaderVersion="[32,)" # This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
 # The license for your mod.
 license="MIT"
 # A URL to refer people to when problems occur with this mod


### PR DESCRIPTION
This PR should fix #3. Changes version compatibility to allow for all forge versions since 1.16.1.